### PR TITLE
Move wifi and homing to sub-configs

### DIFF
--- a/duet/sys/config.g
+++ b/duet/sys/config.g
@@ -5,8 +5,9 @@ M550 PRailCore					; Machine name and Netbios name (can be anything you like)
 ;M551 Pmyrap                        	; Machine password (used for FTP)
 ;*** If you have more than one Duet on your network, they must all have different MAC addresses, so change the last digits
 M540 P0xBE:0xEF:0xDE:0xAD:0xFE:0xEE 	; MAC Address
-;*** Wifi Networking
-M552 S1								; Enable WiFi
+
+M98 P"wifi.g"                       ; Run WiFi configuration file.
+
 M555 P2                           	; Set output to look like Marlin
 M575 P1 B57600 S1					; Comms parameters for PanelDue
 
@@ -21,7 +22,7 @@ M584 X0 Y1 Z5:6:7 E3:4:8:9 		; Map Z to drivers 5, 6, 7. Define unused drivers 3
 M569 P0 S1                          ; Drive 0 goes forwards (change to S0 to reverse it) X stepper
 M569 P1 S0                          ; Drive 1 goes backwards	Y Stepper
 M569 P2 S1                          ; Drive 2 goes forwards		Unused
-M569 P3 S1                          ; Drive 3 goes forwards		Extruder 
+M569 P3 S1                          ; Extruder (Drive 3) S1 for Bondtech, S0 for Titan 
 M569 P4 S1                          ; Drive 4 goes forwards		Extruder (unused)
 M569 P5 S0							; Drive 5 goes backwards	Front Left Z
 M569 P6 S0							; Drive 6 goes backwards	Rear Left Z

--- a/duet/sys/homeall.g
+++ b/duet/sys/homeall.g
@@ -1,33 +1,12 @@
-; homeall file for use with dc42 Duet firmware on CoreXY printers
-; This file assumes the endstop switches are at the low end of each axis.
-; Reverse the X and Y movement for high-end switches.
-; Adjust the bed upper and lower limits in config.g (M208 commands) to get the correct homing positions
+; homeall by executing individual axes homing macros
 
-G91                       ; relative mode
-G1 Z5 S2 F400
-G1 S1 X-320 Y-320 F3000   ; course home X or Y
-G1 S1 X-320               ; course home X
-G1 S1 Y-320               ; course home Y
-G1 X4 Y4 F1200             ; move away from the endstops
-G1 S1 X-10                ; fine home X
-G1 S1 Y-10                ; fine home Y
+; Homing with endstops
+M98 P"homing/homex.g"
+M98 P"homing/homey.g"
+M98 P"homing/homez.g"
 
-; If you are using a microswitch for Z homing, insert similar code for the Z axis here,
-; but use lower feed rates suitable for your Z axis.
-
-G90                       ; back to absolute mode
-
-; If you homed the Z axis using an endstop switch, you can insert a G92 command here to correct the height.
-
-; The following code assumes you are using a Z probe to do Z homing. Remove it if you are using a microswitch.
-; Adjust the XY coordinates in the following to place the Z probe over a suitable spot,
-; preferably near the centre of the bed if your Z probe supports that
-G91
-G1 Z4 F200 S2
-G90
-G1 X150 Y150 F6000
-G30
-; This file leaves the head at the zprobe trigger height so that you can slip a piece of paper under it and then do G0 Z0 to check the height.
-; If you prefer to send the printer to X0Y0Z0, un-comment the following lines
-;G1 X0 Y0 F5000
-;G1 Z0
+; Homing with no endstops (sensorless homing)
+; Comment out the Endstop homing lines above and uncomment these lines to use sensorless homing
+;M98 P"homing/homex-sensorless.g"
+;M98 P"homing/homey-sensorless.g"
+;M98 P"homing/homez.g"

--- a/duet/sys/homing/homex-sensorless.g
+++ b/duet/sys/homing/homex-sensorless.g
@@ -1,0 +1,15 @@
+; home X - Sensorless
+
+M400                    	; make sure everything has stopped before we make changes
+M913 X30 Y30             	; reduce motor current to 30% to prevent belts slipping
+M201 X1000 Y1000                ; reduce acceleration on X/Y to stop false triggers
+M915 P0:1 S3 R0 F0              ; both motors because corexy; Sensitivity 4, don’t take action, don’t filter
+
+G91                   	 	; use relative positioning
+G1 S1 X-270 F4000    		; move to home position
+G1 X25 F2000          		; back off to edge of bed
+
+G90            			; back to absolute positioning
+M400
+M913 X100 Y100        		; motor currents back to normal
+M201 X3000 Y3000                ; accel back to original

--- a/duet/sys/homing/homex.g
+++ b/duet/sys/homing/homex.g
@@ -1,4 +1,5 @@
-; X axis homing file for dc42 Duet firmware
+; Home X Axis
+
 G91
 G1 Z4 F200 S2
 G1 X-320 F3000 S1

--- a/duet/sys/homing/homey-sensorless.g
+++ b/duet/sys/homing/homey-sensorless.g
@@ -1,0 +1,15 @@
+; home Y - Sensorless
+
+M400                    	; make sure everything has stopped before we make changes
+M913 X30 Y30             	; reduce motor current to 50% to prevent belts slipping
+M201 X1000 Y1000                ; reduce acceleration on X/Y to stop false triggers
+M915 P0:1 S3 R0 F0              ; both motors because corexy; Sensitivity 4, don’t take action, don’t filter
+
+G91                   	 	; use relative positioning
+G1 S1 Y-270 F4000    		; move to home position
+G1 Y25 F2000          		; back off to edge of bed
+
+G90            			; back to absolute positioning
+M400
+M913 X100 Y100        		; motor currents back to normal
+M201 X3000 Y3000                ; accel back to original

--- a/duet/sys/homing/homey.g
+++ b/duet/sys/homing/homey.g
@@ -1,4 +1,5 @@
-; Omerod 2 Y homing file for dc42 Duet firmware
+; Home Y Axis
+
 G91
 G1 Z4 F200 S2
 G1 Y-320 F3000 S1

--- a/duet/sys/homing/homez.g
+++ b/duet/sys/homing/homez.g
@@ -1,3 +1,5 @@
+; Home Z Axis
+
 G91
 G1 Z5 F800 S2
 G90

--- a/duet/sys/wifi.g
+++ b/duet/sys/wifi.g
@@ -1,0 +1,5 @@
+; Wifi Networking
+M552 S1                                 ; Enable WiFi
+M587 S"NetworkNameHere" P"PasswordHere" ; Set SSID and Password for WiFi
+M552 P0.0.0.0                           ; Use DHCP
+

--- a/duet/sys/zprobes/README.md
+++ b/duet/sys/zprobes/README.md
@@ -1,0 +1,3 @@
+# Z Probes
+
+Z Probes are used to home Z on the RailCore. There are many probe types in use throughout the community and this readme will serve as a guide on how to config and enable each type. **Note: You should only enable *one* z probe type at a time.**


### PR DESCRIPTION
This is a new style for doing settings on the default RailCore config.

I'm proposing that all configs which can have multiple options will go into a subfolder and then be called via a `M98`.

The reason for this is two fold:

1. It allows us to have multiple configs for Homing for instance without cluttering up the main `sys` folder.
2. We can add a details README.md to each sub-directory that explains all the options, how to wire them up, etc.

I think this pattern will serve us well going forward and allow us to have unique configs up-kept by those who use them (Piezo, IR, etc) and also allow us to have solid documentation around each option.