### PR TITLE
reverse X and Y stepper

### DIFF
--- a/duet/sys/config.g
+++ b/duet/sys/config.g
@@ -18,8 +18,8 @@ M83                                 	; ...but relative extruder moves
 M667 S1								; CoreXY mode
 
 M584 X0 Y1 Z5:6:7 E3:4:8:9 		; Map Z to drivers 5, 6, 7. Define unused drivers 3,4,8 and 9 as extruders
-M569 P0 S1                          ; Drive 0 goes forwards (change to S0 to reverse it) X stepper
-M569 P1 S0                          ; Drive 1 goes backwards	Y Stepper
+M569 P0 S0                          ; Drive 0 goes backwards (change to S1 to reverse it) X stepper
+M569 P1 S1                          ; Drive 1 goes forwards	Y Stepper
 M569 P2 S1                          ; Drive 2 goes forwards		Unused
 M569 P3 S1                          ; Drive 3 goes forwards		Extruder 
 M569 P4 S1                          ; Drive 4 goes forwards		Extruder (unused)


### PR DESCRIPTION
Two people reported they had to reverse X and Y and I had to also reverse both, so the defaults are properly wrong. Z was correct for kit and BOM users.