### PR TITLE
Remove M540 Set MAC address

### DIFF
--- a/duet/sys/config.g
+++ b/duet/sys/config.g
@@ -4,7 +4,6 @@ M111 S0                             	; Debug off
 M550 PRailCore				; Machine name and Netbios name (can be anything you like)
 ;M551 Pmyrap                        	; Machine password (used for FTP)
 ;*** If you have more than one Duet on your network, they must all have different MAC addresses, so change the last digits
-M540 P0xBE:0xEF:0xDE:0xAD:0xFE:0xEE 	; MAC Address
 
 M98 P"wifi.g"                           ; Run WiFi configuration file.
 

--- a/duet/sys/config.g
+++ b/duet/sys/config.g
@@ -3,8 +3,6 @@
 M111 S0                             	; Debug off
 M550 PRailCore				; Machine name and Netbios name (can be anything you like)
 ;M551 Pmyrap                        	; Machine password (used for FTP)
-;*** If you have more than one Duet on your network, they must all have different MAC addresses, so change the last digits
-
 M98 P"wifi.g"                           ; Run WiFi configuration file.
 
 M555 P2                           	; Set output to look like Marlin


### PR DESCRIPTION
This command is not necessary to have, except in unusual circumstances.

Duet 2 Wifi the MAC address is unique and set on the Wifi Module so this command has no effect.
Duet 2 Ethernet is generated from the unique processor ID - there is normally no need to change it, and if it is necessary then the user is advanced enough to add the command in themselves.
We don't need every Duet 2 Ethernet user to have the same MAC address of BEEF DEAD FEEE 
(If it is necessary, then can we have COFFEE DEC0DE? :P )