### PR TITLE
M929 - start logging to file eventlog.txt

### DIFF
--- a/duet/sys/config.g
+++ b/duet/sys/config.g
@@ -1,6 +1,8 @@
 ; Configuration file for RailcoreII 300ZL or ZLT Printer
 ; Communication and general
 M111 S0                             	; Debug off
+M929 P"eventlog.txt" S1			; start logging to file eventlog.txt
+
 M550 PRailCore				; Machine name and Netbios name (can be anything you like)
 ;M551 Pmyrap                        	; Machine password (used for FTP)
 M98 P"wifi.g"                           ; Run WiFi configuration file.


### PR DESCRIPTION
Added logging. 
Many uses. Main ones being that it is useful for users to track prints, as well as debugging for own use (or for sharing with others when there is a problem)

example

```
power up + 00:00:00 Event logging started
power up + 00:00:00 Warning: Heater 1 appears to be over-powered. If left on at full power, its temperature is predicted to reach 714C.
power up + 00:00:01 Warning: Heater 2 appears to be over-powered. If left on at full power, its temperature is predicted to reach 890C.
power up + 00:00:01 WiFi module started
power up + 00:00:06 WiFi module is connected to access point Workshop, IP address 192.168.0.26
power up + 00:00:09 HTTP client 192.168.0.32 login succeeded
2019-02-22 10:19:02 Date and time set at power up + 00:00:09
2019-02-22 10:19:02 HTTP client 192.168.0.34 login succeeded
2019-02-22 10:19:03 HTTP client 192.168.0.32 login succeeded
2019-02-22 11:05:54 HTTP client 192.168.0.32 login succeeded
2019-02-22 13:51:13 HTTP client 192.168.0.32 login succeeded
2019-02-22 13:52:13 Started printing file 300ZLT_Bearing_Block.gcode
```