### PR TITLE
removing comment on M92

### DIFF
--- a/duet/sys/config.g
+++ b/duet/sys/config.g
@@ -47,7 +47,7 @@ M203 X24000 Y24000 Z900 E3600  		; Maximum speeds (mm/min)
 M566 X1000 Y1000 Z30 E20 		; Maximum jerk speeds mm/minute
 M208 X290 Y290 Z280 			; Set axis maxima and high homing switch positions (adjust to suit your machine)
 M208 X0 Y0 Z-0.5 S1 			; Set axis minima and low homing switch positions (adjust to make X=0 and Y=0 the edges of the bed)
-M92 X200 Y200 Z1600 E837 		; Steps/mm, X/Y may be more around 201.5 for accuracy
+M92 X200 Y200 Z1600 E837 		; Steps/mm
 
 ; Thermistors
 M305 P0 T100000 B4240 R4700 H0 L0	; Put your own H and/or L values here to set the bed thermistor ADC correction


### PR DESCRIPTION
Discord 16 March 2018

**RiskyBirdness Today at 06:20**
What is mean by this line in the config file:
M92 X200 Y200 Z1600 E837        ; steps/mm, X/Y may be more around 201.5 for accuracy
Why is "201.5 for accuracy" and if accuracy is good, why isn't it set to that by default?
Is 201.5 to account for backlash?

**jstevewhiteToday at 13:08**
We should probably remove that comment. On my original build ther ewas a small systemic variance from 200 steps/mm I still haven't figured out. Anyway, there are better ways to adjust part size to spec now (later versions of Duet RRF), so that's not even relevant now