### PR TITLE
2-stage homez.g

### DIFF
--- a/duet/sys/config.g
+++ b/duet/sys/config.g
@@ -78,6 +78,7 @@ G10 P0 S0 R0                            ; Set tool 0 operating and standby tempe
 ;IR Probe or Switch
 ;*** Comment this section out (or remove) if you are NOT using an IR Probe or Switch
 ;*** If you have a switch instead of an IR probe, change P1 to P4 in the following M558 command
+;*** Do not use the Fxxx parameter for M558 here, it is set in homez.g
 M558 P1 X0 Y0 Z1                        ; Z probe is an IR probe and is not used for homing any axes
 G31 X0 Y30 Z2.00 P500                   ; Set the zprobe height and threshold (put your own values here)
                                         ; Tip: A larger trigger height in G31 moves you CLOSER to the bed

--- a/duet/sys/homez.g
+++ b/duet/sys/homez.g
@@ -1,8 +1,14 @@
 ; Home Z Axis
 
-G91
-G1 Z5 F800 S2
-G90
-G1 X150 Y150 F6000
+G91 G1 Z5 F800 S2 ; lift z so we don't crash
+G90 G1 X150 Y150 F6000 ; Move to the center of the bed
+
+; M558  Fxxx sets the probing speed.
+; Probe rapidly to get us in the right ballpark.
+; This brings the bed up quickly but may be less accurate.
+M558 F500
 G30
-G1 Z2 F200
+
+; Probe again slowly for precision
+M558 F50
+G30

--- a/duet/sys/homez.g
+++ b/duet/sys/homez.g
@@ -1,4 +1,6 @@
-; Home Z Axis
+;File     : homez.g
+;Effect   : does a 2-stage Z-homing. Once quickly to bring the bed up from a long distance quickly, then again slower for better accuracy.
+;Use-case : the machine may be Z-homed from any position at a reasonable pace, without resorting to dangerous options such as M564 H0 - while still retaining accuracy of the final probe.
 
 G91 G1 Z5 F800 S2 ; lift z so we don't crash
 G90 G1 X150 Y150 F6000 ; Move to the center of the bed


### PR DESCRIPTION
This script does a 2-stage Z-homing.  Once quickly to bring the bed up from a long distance quickly, then again slower for better accuracy.

Doing it this way lets the machine be homed from any position at a reasonable pace, without resorting to dangerous options such as `M564 H0` - while still retaining accuracy of the final probe.