### PR TITLE
Conservative mode

### DIFF
--- a/duet/sys/config.g
+++ b/duet/sys/config.g
@@ -92,3 +92,7 @@ G31 X0 Y30 Z2.00 P500                   ; Set the zprobe height and threshold (p
 
 M208 S1 Z-0.2                           ; set minimum Z
 T0                                      ; select first hot end
+
+; Conservative settings enabled during build and testing. When you are ready to remove this
+; simple protection, remove or comment out this line
+; M98 P"conservative.g

--- a/duet/sys/config.g
+++ b/duet/sys/config.g
@@ -54,7 +54,7 @@ M305 P0 T100000 B4240 R4700 H0 L0       ; Put your own H and/or L values here to
 M305 P1 T100000 B4240 R4700 H0 L0       ; Put your own H and/or L values here to set the first nozzle thermistor ADC correction
 
 ;Heaters
-M307 H1 A270.7 C90.4 D6.7 B0 S1.0       ; Heater 1 model
+
 M570 S360                               ; Hot end may be a little slow to heat up so allow it 360 seconds
 M143 S285                               ; Maximum heater temperature
 
@@ -95,4 +95,5 @@ T0                                      ; select first hot end
 
 ; Conservative settings enabled during build and testing. When you are ready to remove this
 ; simple protection, remove or comment out this line
-; M98 P"conservative.g
+; M98 P"conservative.g"
+M501                                    ; Load saved parameters from non-volatile memory

--- a/duet/sys/conservative.g
+++ b/duet/sys/conservative.g
@@ -1,17 +1,22 @@
-; Axis and motor configuration
+;File     : conservative.g
+;Effect   : Slows down the printer, adjusts probing to give more leeway, puts in a default heater model.
+;Use-case : Enabled by default, for use during commissioning in order to either prevent or minimise the effects
+;           of crashing the head into the bed or anything else and to ensure there is a heater model before tuning.
+
+; Axis and motor configuration - slow down.
 M201 X1500 Y1500 Z10 E500      ; Reduce accelerations (mm/s^2)
 M203 X12000 Y12000 Z450 E1800   ; Reduce maximum speeds (mm/min)
 M566 X500 Y500 Z15 E10        ; Reduce maximum jerk speeds mm/minute
 
-; Heater model
-M307 H0 A270.7 C90.4 D6.7 B0 S1.0          ; Default Bed Heater Parameters, before tuning / if config-override.g is missing
-M307 H1 A508.1 C249.0 D3.8 S1.00 V24.2 B0  ; Default Tool Heater Parameters, before tuning / if config-override.g is missing
-
-M558 H10 F50 T3000 ; Z probe
+M558 H10 F50 T3000 ; Z probe - slow and raise probe height.
                    ; H10 - dive height
                    ; F50 - probing speed
                    ; T3000 - travel speed between probe points
-                   ; Bigger dive height prevents a situation where the bed is offset by more than the dive height
-                   ; on any corner during commissioning, crashing the hot-end.
+                   ; A bigger dive height prevents a situation where the bed is out of alignment by more than the dive height
+                   ; on any corner, which can crash the hot-end into the bed while moving the head in XY.
                    ; Probing speed and travel speed are similarly reduced in case the Z probe isn't connected properly (or
-                   ; disconnects later after moving to a point)
+                   ; disconnects later after moving to a point) giving the user more time to stop.
+
+; Default heater model
+M307 H0 A270.7 C90.4 D6.7 B0 S1.0          ; Default Bed Heater Parameters, before tuning / if config-override.g is missing
+M307 H1 A508.1 C249.0 D3.8 S1.00 V24.2 B0  ; Default Tool Heater Parameters, before tuning / if config-override.g is missing

--- a/duet/sys/conservative.g
+++ b/duet/sys/conservative.g
@@ -7,6 +7,11 @@ M566 X500 Y500 Z15 E10        ; Maximum jerk speeds mm/minute
 M307 H0 A270.7 C90.4 D6.7 B0 S1.0          ; Default Bed Heater Parameters, before tuning
 M307 H1 A508.1 C249.0 D3.8 S1.00 V24.2 B0  ; Default Tool Heater Parameters, before tuning
 
-M558 H10 F50 T3000	; Z probe
-                    ; Dive height (H8). Speeds 
-                    ; (Probe - F50, travel - T3000).
+M558 H10 F50 T3000 ; Z probe
+                   ; H10 - dive height
+                   ; F50 - probing speed
+                   ; T3000 - travel speed between probe points
+                   ; Bigger dive height prevents a situation where the bed is offset by more than the dive height
+                   ; on any corner during commissioning, crashing the hot-end.
+                   ; Probing speed and travel speed are similarly reduced in case the Z probe isn't connected properly (or
+                   ; disconnects later after moving to a point)

--- a/duet/sys/conservative.g
+++ b/duet/sys/conservative.g
@@ -1,11 +1,11 @@
 ; Axis and motor configuration
-M201 X1500 Y1500 Z10 E500      ; Accelerations (mm/s^2)
-M203 X12000 Y12000 Z450 E1800   ; Maximum speeds (mm/min)
-M566 X500 Y500 Z15 E10        ; Maximum jerk speeds mm/minute
+M201 X1500 Y1500 Z10 E500      ; Reduce accelerations (mm/s^2)
+M203 X12000 Y12000 Z450 E1800   ; Reduce maximum speeds (mm/min)
+M566 X500 Y500 Z15 E10        ; Reduce maximum jerk speeds mm/minute
 
 ; Heater model
-M307 H0 A270.7 C90.4 D6.7 B0 S1.0          ; Default Bed Heater Parameters, before tuning
-M307 H1 A508.1 C249.0 D3.8 S1.00 V24.2 B0  ; Default Tool Heater Parameters, before tuning
+M307 H0 A270.7 C90.4 D6.7 B0 S1.0          ; Default Bed Heater Parameters, before tuning / if config-override.g is missing
+M307 H1 A508.1 C249.0 D3.8 S1.00 V24.2 B0  ; Default Tool Heater Parameters, before tuning / if config-override.g is missing
 
 M558 H10 F50 T3000 ; Z probe
                    ; H10 - dive height

--- a/duet/sys/conservative.g
+++ b/duet/sys/conservative.g
@@ -1,0 +1,12 @@
+; Axis and motor configuration
+M201 X1500 Y1500 Z10 E500      ; Accelerations (mm/s^2)
+M203 X12000 Y12000 Z450 E1800   ; Maximum speeds (mm/min)
+M566 X500 Y500 Z15 E10        ; Maximum jerk speeds mm/minute
+
+; Heater model
+M307 H0 A270.7 C90.4 D6.7 B0 S1.0          ; Default Bed Heater Parameters, before tuning
+M307 H1 A508.1 C249.0 D3.8 S1.00 V24.2 B0  ; Default Tool Heater Parameters, before tuning
+
+M558 H10 F50 T3000	; Z probe
+                    ; Dive height (H8). Speeds 
+                    ; (Probe - F50, travel - T3000).


### PR DESCRIPTION
The point of this patch is to create file for all newly built units to have a default, safer config.
I ran this myself when commissioning (perhaps it should be called "commissioning" mode instead , lol) and it was great. Gave me piece of mind and more reaction time during the inevitable head crashes (because my probe wasn't hooked up) :D

Currently has:

- Default heater models can be stored here
- Slower travel limits
- Probing with higher dive height (to prevent gouged beds, which is what I learnt) and set to a slow speed.

And can contain anything else you see fit for first run scenarios.