### PR TITLE
M570 corrections

### DIFF
--- a/duet/sys/config.g
+++ b/duet/sys/config.g
@@ -55,8 +55,9 @@ M305 P1 T100000 B4240 R4700 H0 L0       ; Put your own H and/or L values here to
 
 ;Heaters
 
-M570 S360                               ; Hot end may be a little slow to heat up so allow it 360 seconds
-M143 S285                               ; Maximum heater temperature
+M570 S360                                  ; Print will be terminated if a heater fault is not reset within 360 minutes.
+M143 H0 S120                               ; Maximum H0 (Bed) heater temperature
+M143 H1 S285                               ; Maximum H1 (Extruder) heater temperature
 
 ; Fans
 M106 P0 H-1                             ; Disable thermostatic mode for fan 0


### PR DESCRIPTION
No heater number - was this for the hotend or the bed. Clarified.
S360 - I'm not sure this was doing what it was intended to do? Pre firmware 1.15 it would fault after 360 seconds, but now "Snnn Timeout in minutes for print to be cancelled after heater fault (Firmware 1.20 and later)." 
So cancel print 6 hours after the heater faults???

Pnnn and Tnnn are used now for heater faults. (Default P5 and T15 - see https://duet3d.dozuki.com/Wiki/Gcode#Section_M570_Configure_heater_fault_detection)

Specified maximum temperature for hotend and bed.