### PR TITLE
Slow down z

### DIFF
--- a/duet/sys/homez.g
+++ b/duet/sys/homez.g
@@ -8,7 +8,8 @@ G90 G1 X150 Y150 F6000 ; Move to the center of the bed
 ; M558  Fxxx sets the probing speed.
 ; Probe rapidly to get us in the right ballpark.
 ; This brings the bed up quickly but may be less accurate.
-M558 F500
+; Initially set to 150 for commissioning, 500 is being used when printer is fully commissioned.
+M558 F150
 G30
 
 ; Probe again slowly for precision

--- a/duet/sys/homez.g
+++ b/duet/sys/homez.g
@@ -8,8 +8,8 @@ G90 G1 X150 Y150 F6000 ; Move to the center of the bed
 ; M558  Fxxx sets the probing speed.
 ; Probe rapidly to get us in the right ballpark.
 ; This brings the bed up quickly but may be less accurate.
-; Initially set to 150 for commissioning, 500 is being used when printer is fully commissioned.
-M558 F150
+; Initially set to F75 for commissioning, F500 can be used when printer is fully commissioned.
+M558 F75
 G30
 
 ; Probe again slowly for precision


### PR DESCRIPTION
I'm worried that F500 could be potentially used by default while commissioning, so I propose slowing it down and commenting in the full speed settings to be changed later.

That OK?