### PR TITLE
Correct thermistor values

### DIFF
--- a/duet/sys/config.g
+++ b/duet/sys/config.g
@@ -55,8 +55,8 @@ M208 X0:280 Y0:280 Z-0.2:280            ; 300ZL
 ; M208 X0:280 Y0:280 Z-0.2:580          ; 300ZLT
 
 ; Thermistors
-M305 P0 T100000 B4240 R4700 H0 L0       ; Put your own H and/or L values here to set the bed thermistor ADC correction
-M305 P1 T100000 B4240 R4700 H0 L0       ; Put your own H and/or L values here to set the first nozzle thermistor ADC correction
+M305 P0 S"Bed" T100000 B3950 R4700 H0 L0          ; BOM thermistor values. Put your own H and/or L values here to set the bed thermistor ADC correction
+M305 P1 S"E0" T100000 B4725 C7.06e-8 R4700 H0 L0  ; E3D Semitec 104GT2 thermistor values. Put your own H and/or L values here to set the first nozzle thermistor ADC correction
 
 ;Heaters
 M570 S360                                  ; Print will be terminated if a heater fault is not reset within 360 minutes.


### PR DESCRIPTION
(as per FB, repeating here for clarity)

@kraegar 
> Gerard Hudson brought it to my attention that the kit config has an incorrect thermistor value for the e3d thermistor. Everyone, kit or not, should double check their thermistor Beta values. These being wrong can lead to a value for the hotend being reported up to 20c too low. 
> (I had corrected this at one point, but must have somehow copied an old config.g back in over the new one and recreated the earlier mistake.)
> 
> The kit config.g has a Beta value for both thermisters of B4240. If your hot end thermistor is an E3D Semitec 104GT2 it should be B4725. The bed thermistor should be B3950.

OK, Here is what I've learned.

1) Bed set at 80°C with old value. My IR thermometer reads 83°C in the middle of the bed. 
Put in "M305 P0 B3950" in the G-code console - Duet reading changes to 83.1°C - perfect!

2) Hot-end set to 240°C. Can't use IR thermometer for this. Plug "M305 P1 B4725" into the Duet. Temp changes from 240°C to 197°C. 
I investigate further and end up at https://www.makeralot.com/download/Reprap-Hotend-Thermistor-NTC-3950-100K.pdf and learn that we should probably be using "C7.06e-8" as well.
Temp changes from 240°C to 219.7°C , which in the absence of measuring equipment (can anyone chime in here?) will do for now for me.