### PR TITLE
Add G4's to solve potential timing issues

### DIFF
--- a/duet/macros/Commissioning/1_Motion_Test.g
+++ b/duet/macros/Commissioning/1_Motion_Test.g
@@ -7,9 +7,9 @@
 
 M84; disable motors to allow manual movement
 M291 R"Self Test" P"Slowly move print head near the center of the bed" S3
-G4 P500
+G4 P500 ; workaround, see https://github.com/railcore/configs/pull/63
 M291 R"Self Test" P"Make sure the bed is well away from the nozzle" S3
-G4 P500
+G4 P500 ; workaround, see https://github.com/railcore/configs/pull/63
 
 ; Test each x/y motor in isolation.  The S2 parameter makes each motor axis behave independently, not like a core-xy
 M291 R"Self Test" P"Rear X/Y motor will move clockwise" S3

--- a/duet/macros/Commissioning/1_Motion_Test.g
+++ b/duet/macros/Commissioning/1_Motion_Test.g
@@ -7,7 +7,9 @@
 
 M84; disable motors to allow manual movement
 M291 R"Self Test" P"Slowly move print head near the center of the bed" S3
+G4 P500
 M291 R"Self Test" P"Make sure the bed is well away from the nozzle" S3
+G4 P500
 
 ; Test each x/y motor in isolation.  The S2 parameter makes each motor axis behave independently, not like a core-xy
 M291 R"Self Test" P"Rear X/Y motor will move clockwise" S3


### PR DESCRIPTION
On my machine this does not work

```
M84; disable motors to allow manual movement

M291 R"Self Test" P"Slowly move print head near the center of the bed" S3
M291 R"Self Test" P"Make sure the bed is well away from the nozzle" S3
```

After the first M291 (click OK) it hangs saying "busy"
However, this does work

```
M84; disable motors to allow manual movement
M291 R"Self Test" P"Slowly move print head near the center of the bed" S3
G4 P500
M291 R"Self Test" P"Make sure the bed is well away from the nozzle" S3
G4 P500
```

(RepRapFirmware for Duet 2 WiFi/Ethernet 2.03beta3 (2019-03-25b6 & Duet Web Control 2.0.0-RC6)

I'll report to Duet3D. If it does occur to other people, I guess it's a bug.