### PR TITLE
Backup config user

### DIFF
--- a/duet/sys/config-user examples/config-user.example
+++ b/duet/sys/config-user examples/config-user.example
@@ -6,6 +6,8 @@
 ;         *** feel free to delete anything in here that you are not using.       ***
 ;         **************************************************************************
 
+M28 /sys/config-user.bak ; Backup measure. Backup config-user.g to config-user.bak
+
 ; Z probe and compensation definition
 ; *** WARNING - **Always** make sure your cables are correct, secure and test them thoroughly before homing Z for the first times!
 ; INSTRUCTIONS :   1) Uncomment your configuration lines
@@ -79,3 +81,5 @@
 ;M551 P"myrap"                          ; Machine password (used for FTP)
 ; Telnet
 ;M586 P2 S0                             ; Disable Telnet (default) S1 to enable
+
+M29                                     ; Close config-user.bak

--- a/duet/sys/config-user examples/config-user.example
+++ b/duet/sys/config-user examples/config-user.example
@@ -82,4 +82,4 @@ M28 /sys/config-user.bak ; Backup measure. Backup config-user.g to config-user.b
 ; Telnet
 ;M586 P2 S0                             ; Disable Telnet (default) S1 to enable
 
-M29                                     ; Close config-user.bak
+M29                                    ; Backup measure. Close config-user.bak

--- a/duet/sys/config-user examples/config-user.kit
+++ b/duet/sys/config-user examples/config-user.kit
@@ -12,6 +12,8 @@
 ;                   b) Z is the trigger height (how high your nozzle is from the bed when the probe triggers). You need to dial those in.
 ; c) Tip: A larger trigger height in G31 moves you CLOSER to the bed
 
+M28 /sys/config-user.bak ; Backup measure. Backup config-user.g to config-user.bak
+
 ; ** REMEMBER to place deployprobe.g and retractprobe.g from the bltouch directory into the /sys directory and read the README CAREFULLY.
 M558 P9                             ; BL-touch 
 G31 X2 Y42 Z2.65 P25                ; BL-touch 
@@ -40,3 +42,5 @@ M143 H0 S120                        ; Maximum H0 (Bed) heater temperature
 M563 P0 S"E3Dv6 Gold" D0 H1         ; Define tool 0 uses extruder 0, heater 1 
 G10 P0 X0 Y0 Z0                     ; Set tool 0 axis offsets
 M143 H1 S290                        ; Maximum H1 (Extruder) heater temperature (E3D requires 285C to change nozzle)
+
+M29                                 ; Close config-user.bak

--- a/duet/sys/config-user examples/config-user.selfbuild
+++ b/duet/sys/config-user examples/config-user.selfbuild
@@ -3,6 +3,8 @@
 ;Use-case : By keeping any custom definitions in this file (such as Z probe attributes, axis minima/maxima and anything else that you wish to override in config.g
 ;         : it will enable the user to easily keep track of their own changes to the default config, as well as provide a simple upgrade path for future Github releases.
 
+M28 /sys/config-user.bak ; Backup measure. Backup config-user.g to config-user.bak
+
 ; Z probe and compensation definition
 ; *** WARNING - **Always** make sure your cables are correct, secure and test them thoroughly before homing Z for the first times!
 ; INSTRUCTIONS :   1) Uncomment your configuration lines
@@ -45,3 +47,5 @@ G10 P0 X0 Y0 Z0                    ; Set tool 0 axis offsets
 M143 H1 S290                       ; Maximum H1 (Extruder) heater temperature (E3D requires 285C to change nozzle)
 
 M557 X50:290 Y50:290 S240 S240     ; Set Default Mesh
+
+M29                                ; Backup measure. Close config-user.bak


### PR DESCRIPTION
My config-user got wiped by a DWC bug while editing (luckily I was able to rebuild fairly easily from this repo)

This creates a rudimentary backup of config-user.g to config-user.bak in /sys on each restart - for emergencies.

Tested. Works great , other than creating no date stamp on the file.