### PR TITLE
Wifi modification

### DIFF
--- a/duet/sys/config-user examples/config-user.example
+++ b/duet/sys/config-user examples/config-user.example
@@ -79,3 +79,8 @@
 ;M551 P"myrap"                          ; Machine password (used for FTP)
 ; Telnet
 ;M586 P2 S0                             ; Disable Telnet (default) S1 to enable
+
+
+; M98 P"wifi.g"                     ; Run WiFi configuration file , only run wifi.g UNTIL YOU ARE CONNECTED AND THEN DELETE.  
+                                    ; As well as being a security hazard, writing the access point parameters to WiFi chip every
+                                    ; time you start the Duet may eventually wear out the flash memory.

--- a/duet/sys/config-user examples/config-user.kit
+++ b/duet/sys/config-user examples/config-user.kit
@@ -40,3 +40,7 @@ M143 H0 S120                        ; Maximum H0 (Bed) heater temperature
 M563 P0 S"E3Dv6 Gold" D0 H1         ; Define tool 0 uses extruder 0, heater 1 
 G10 P0 X0 Y0 Z0                     ; Set tool 0 axis offsets
 M143 H1 S290                        ; Maximum H1 (Extruder) heater temperature (E3D requires 285C to change nozzle)
+
+; M98 P"wifi.g"                     ; Run WiFi configuration file , only run wifi.g UNTIL YOU ARE CONNECTED AND THEN DELETE.  
+                                    ; As well as being a security hazard, writing the access point parameters to WiFi chip every
+                                    ; time you start the Duet may eventually wear out the flash memory.

--- a/duet/sys/config-user examples/config-user.selfbuild
+++ b/duet/sys/config-user examples/config-user.selfbuild
@@ -45,3 +45,7 @@ G10 P0 X0 Y0 Z0                    ; Set tool 0 axis offsets
 M143 H1 S290                       ; Maximum H1 (Extruder) heater temperature (E3D requires 285C to change nozzle)
 
 M557 X50:290 Y50:290 S240 S240     ; Set Default Mesh
+
+; M98 P"wifi.g"                     ; Run WiFi configuration file , only run wifi.g UNTIL YOU ARE CONNECTED AND THEN DELETE.  
+                                    ; As well as being a security hazard, writing the access point parameters to WiFi chip every
+                                    ; time you start the Duet may eventually wear out the flash memory.

--- a/duet/sys/config.g
+++ b/duet/sys/config.g
@@ -6,7 +6,6 @@ M111 S0                                 ; Debug off
 M929 P"eventlog.txt" S1                 ; Start logging to file eventlog.txt
 M550 P"RailCore"                        ; Machine name and Netbios name (can be anything you like)
 
-M98 P"wifi.g"                           ; Run WiFi configuration file.
 M552 P0.0.0.0                           ; Use DHCP
 
 ; General preferences


### PR DESCRIPTION
Quick fix for wifi.g in config.g

 https://duet3d.dozuki.com/Wiki/Gcode#Section_M587_Add_WiFi_host_network_to_remembered_list_or_list_remembered_networks

"Important! Do not use M587 within config.g. As well as being a security hazard, writing the access point parameters to WiFi chip every time you start the Duet may eventually wear out the flash memory."
