### PR TITLE
Updated Z Offset to 0 to reduce chance of nozzle crashes

### DIFF
--- a/duet/sys/config-user examples/bltouch/config-user.bltouch
+++ b/duet/sys/config-user examples/bltouch/config-user.bltouch
@@ -3,5 +3,5 @@
 
 ; Z probe and compensation definition
 M558 P9                 ; BL-touch 
-G31 X2 Y42 Z2.65 P25    ; BL-touch 
+G31 X2 Y42 Z0 P25       ; BL-touch - Z Offset set to 0, determine your own Z-Offset and enter it here (Note: Positive number is closer to the bed)
 M307 H3 A-1 C-1 D-1     ; BL-touch : remaps some channels to make the PWM port on the Duex5 work for a Z-probe if you use a different PWM port than the docs show, you have to change that

--- a/duet/sys/config-user examples/config-user.example
+++ b/duet/sys/config-user examples/config-user.example
@@ -20,13 +20,13 @@
 ;M307 H3 A-1 C-1 D-1     ; BL-touch : remaps some channels to make the PWM port on the Duex5 work for a Z-probe if you use a different PWM port than the docs show, you have to change that
 
 ;M558 P1                 ; IR probe Probing configuration          
-;G31 X0 Y35 Z2.00 P500   ; IR probe Probing configuration
+;G31 X0 Y35 Z0 P500      ; IR probe Probing configuration Z Offset set to 0, determine your own Z-Offset and enter it here (Note: Positive number is closer to the bed)
 
 ;M558 P8 I1 R0.75 S0.005 ; Orion *** WARNING: This section has not been tested throughly yet, and is based off community input. Use at your own risk.
 ;G31 X0 Y0 Z0.00 P500    ; Orion Probing configuration
 
 ;M558 P4                 ; Switch Probing configuration
-;G31 X0 Y30 Z2.00 P500   ; Switch Probing configuration
+;G31 X0 Y30 Z0 P500      ; Switch Probing configuration Z Offset set to 0, determine your own Z-Offset and enter it here (Note: Positive number is closer to the bed)
 
 ; Drives
 ;M569 P3 S0                              ; Project R3D : Drive 3 goes backwards - Extruder 

--- a/duet/sys/config-user examples/config-user.example
+++ b/duet/sys/config-user examples/config-user.example
@@ -16,7 +16,7 @@
 ; c) Tip: A larger trigger height in G31 moves you CLOSER to the bed
 
 ;M558 P9                 ; BL-touch 
-;G31 X2 Y42 Z2.65 P25    ; BL-touch 
+;G31 X2 Y42 Z0 P25       ; BL-touch - Z Offset set to 0, determine your own Z-Offset and enter it here (Note: Positive number is closer to the bed)
 ;M307 H3 A-1 C-1 D-1     ; BL-touch : remaps some channels to make the PWM port on the Duex5 work for a Z-probe if you use a different PWM port than the docs show, you have to change that
 
 ;M558 P1                 ; IR probe Probing configuration          

--- a/duet/sys/config-user examples/config-user.kit
+++ b/duet/sys/config-user examples/config-user.kit
@@ -14,7 +14,7 @@
 
 ; ** REMEMBER to place deployprobe.g and retractprobe.g from the bltouch directory into the /sys directory and read the README CAREFULLY.
 M558 P9                             ; BL-touch 
-G31 X2 Y42 Z2.65 P25                ; BL-touch 
+G31 X2 Y42 Z0 P25                   ; BL-touch - Z Offset set to 0, determine your own Z-Offset and enter it here (Note: Positive number is closer to the bed)
 M307 H3 A-1 C-1 D-1                 ; BL-touch : remaps some channels to make the PWM port on the Duex5 work for a Z-probe if you use a different PWM port than the docs show, you have to change that
 M558 H5 A3 T6000                    ; Set 5mm dive height, 3 probes and 6000 travel speed.
 

--- a/duet/sys/config-user examples/config-user.selfbuild
+++ b/duet/sys/config-user examples/config-user.selfbuild
@@ -13,7 +13,7 @@
 ;                   c) Tip: A larger trigger height in G31 moves you CLOSER to the bed
 
 M558 P1                 ; IR probe Probing configuration          
-G31 X0 Y35 Z2.00 P500   ; IR probe Probing configuration
+G31 X0 Y35 Z0.00 P500   ; IR probe Probing configuration Z Offset set to 0, determine your own Z-Offset and enter it here (Note: Positive number is closer to the bed)
 
 M558 H5 A3 T6000        ; Set 5mm dive height, 3 probes and 6000 travel speed.
 


### PR DESCRIPTION
The Z-Offset in config-user.kit is currently set to 2.65mm, when I built the kit I found it to be closer to 1.65mm. Leaving it at 2.65 may cause users to have nozzle crashes and ruin their print surfaces. By changing it to 0 it will force users to find their own Z-Offset. 