### PR TITLE
Update slow extruder

### DIFF
--- a/duet/sys/config-user examples/config-user.example
+++ b/duet/sys/config-user examples/config-user.example
@@ -34,9 +34,9 @@
 ; Axis and motor configuration - Faster speeds, so uncomment only when fully commissioned!
 ;M906 X1000 Y1000 Z1000 E700 I60         ; Set stock motor currents (mA)
 ;M906 X1400 Y1400 Z1000 E1250 I60        ; Project R3D : Set motor currents (mA)
-;M201 X3000 Y3000 Z20 E1000              ; Accelerations (mm/s^2)
+;M201 X3000 Y3000 Z20 E3000              ; Accelerations (mm/s^2)
 ;M203 X24000 Y24000 Z900 E3600           ; Maximum speeds (mm/min)
-;M566 X1000 Y1000 Z30 E20                ; Maximum jerk speeds mm/minute
+;M566 X1000 Y1000 Z80 E3600              ; Maximum jerk speeds mm/minute
 
 ; Leadscrew motor configuration
 ; M92 Z3200                               ; Steps/mm for Z - TR8*2 / 0.9 deg stepper 

--- a/duet/sys/config-user examples/config-user.kit
+++ b/duet/sys/config-user examples/config-user.kit
@@ -20,9 +20,9 @@ M558 H5 A3 T6000                    ; Set 5mm dive height, 3 probes and 6000 tra
 
 ; Axis and motor configuration - Faster speeds, so uncomment only when fully commissioned!
 ;M906 X1400 Y1400 Z1000 E1250 I60    ; Set motor currents (mA)
-;M201 X3000 Y3000 Z20 E1000          ; Accelerations (mm/s^2)
+;M201 X3000 Y3000 Z20 E3000          ; Accelerations (mm/s^2)
 ;M203 X24000 Y24000 Z900 E3600       ; Maximum speeds (mm/min)
-;M566 X1000 Y1000 Z1300 E20          ; Maximum jerk speeds mm/minute
+;M566 X1000 Y1000 Z30 E3600          ; Maximum jerk speeds mm/minute
 
 ; Drives
 M569 P3 S0                          ; Project R3D : Drive 3 goes backwards - Extruder 

--- a/duet/sys/config-user examples/config-user.selfbuild
+++ b/duet/sys/config-user examples/config-user.selfbuild
@@ -19,9 +19,9 @@ M558 H5 A3 T6000        ; Set 5mm dive height, 3 probes and 6000 travel speed.
 
 ; Axis and motor configuration - Faster speeds, so uncomment only when fully commissioned!
 M906 X1000 Y1000 Z1000 E700 I60     ; Set stock motor currents (mA)
-;M201 X3000 Y3000 Z20 E1000          ; Accelerations (mm/s^2)
+;M201 X3000 Y3000 Z20 E3000          ; Accelerations (mm/s^2)
 ;M203 X24000 Y24000 Z900 E3600       ; Maximum speeds (mm/min)
-;M566 X1000 Y1000 Z1300 E20          ; Maximum jerk speeds mm/minute
+;M566 X1000 Y1000 Z80 E3600          ; Maximum jerk speeds mm/minute
 
 ; Extruder
 ;M92 E415                            ; Extruder - Bondtech BMG Steps/mm (Standard BMG pancake stepper 17HS10-0704S @ 1.8 deg/step)


### PR DESCRIPTION
Correcting slow extruder (and a Z acceleration value), in the example files. 

IIRC someone else was going to correct these, or they accidentally got reverted back at some point.

Values taken from [JohnO's config when talking about PA](https://forum.duet3d.com/topic/8683/pressure-advance-messing-with-travel-moves/21). It's generally seen to by the more experienced members that E jerk and acceleration is too low.
(And for PA they can go higher)

Also Z jerk on the kit was wrong..
