### PR TITLE
Remove dangerous setting

### DIFF
--- a/duet/macros/3_Allow_Move_Without_Homing.g
+++ b/duet/macros/3_Allow_Move_Without_Homing.g
@@ -1,4 +1,4 @@
 ;File     : AllowMoveNoHoming.g
 ;Effect   : Allows the movement of axes before homing.
 ;Use-case : For use in scenarios where you can't home before movement for some reason. e.g. a sensor is broken
-M564 S0 H0
+M564 H0


### PR DESCRIPTION
Removed the `S0` as this allows moves beyond the axis limits. This should really be explicitly requested in a separate macro or this macro be renamed.