### PR TITLE
Adjust default hotend fan settings

### DIFF
--- a/duet/sys/config.g
+++ b/duet/sys/config.g
@@ -62,11 +62,15 @@ M307 H0 A270.7 C90.4 D6.7 B0 S1.0          ; Default Bed Heater Parameters, befo
 M307 H1 A508.1 C249.0 D3.8 S1.00 V24.2 B0  ; Default Tool Heater Parameters, before tuning / if config-override.g is missing
 
 ; Fans
-M106 P0 H-1                             ; Disable thermostatic mode for fan 0
-M106 P1 H-1                             ; Disable thermostatic mode for fan 1
+M106 P1 H-1                             ; Disable thermostatic mode for hotend fan. 
+;M106 P1 H1 T40 B0.1					; Enable thermostatic mode for hotend fan. (Optional) 
+
+M106 P0 H-1                             ; Disable thermostatic mode for parts cooling fan
 M106 P2 H-1                             ; Disable thermostatic mode for fan 2
-M106 P0 S0                              ; Turn off fans
-M106 P1 S0
+
+; Set default fan speeds
+M106 P1 S1								; Turn on hotend fan
+M106 P0 S0                              ; Turn off parts cooling fan(s)
 M106 P2 S0
 
 ; Tool definitions

--- a/duet/sys/config.g
+++ b/duet/sys/config.g
@@ -63,13 +63,13 @@ M307 H1 A508.1 C249.0 D3.8 S1.00 V24.2 B0  ; Default Tool Heater Parameters, bef
 
 ; Fans
 M106 P1 H-1                             ; Disable thermostatic mode for hotend fan. 
-;M106 P1 H1 T40 B0.1					; Enable thermostatic mode for hotend fan. (Optional) 
+;M106 P1 H1 T40 B0.1                    ; Enable thermostatic mode for hotend fan. (Optional) 
 
 M106 P0 H-1                             ; Disable thermostatic mode for parts cooling fan
 M106 P2 H-1                             ; Disable thermostatic mode for fan 2
 
 ; Set default fan speeds
-M106 P1 S1								; Turn on hotend fan
+M106 P1 S1                              ; Turn on hotend fan
 M106 P0 S0                              ; Turn off parts cooling fan(s)
 M106 P2 S0
 
@@ -79,11 +79,11 @@ G10 P0 S-273 R-273                      ; Set tool 0 operating and standby tempe
 
 ; Z probe
 M558 H10 A1 T3000  S0.02                ; Z probe - raise probe height.
-					; H10 - dive height
-					; A bigger dive height prevents a situation where the bed is out of alignment by more than the dive height
-					; on any corner, which can crash the hot-end into the bed while moving the head in XY.
-					; Probing speed and travel speed are similarly reduced in case the Z probe isn't connected properly (or
-					; disconnects later after moving to a point) giving the user more time to stop.
+                    ; H10 - dive height
+                    ; A bigger dive height prevents a situation where the bed is out of alignment by more than the dive height
+                    ; on any corner, which can crash the hot-end into the bed while moving the head in XY.
+                    ; Probing speed and travel speed are similarly reduced in case the Z probe isn't connected properly (or
+                    ; disconnects later after moving to a point) giving the user more time to stop.
 
 M557 X50:200 Y50:200 S150 S150          ; Set Default Mesh (conservative)
 


### PR DESCRIPTION
Change suggested per a discussion on Discord. We've had a number of users struggle to get the hotend fan running recently. This should provide a safer default setting while making the config change to thermostatic mode clearer.

Previous config turns off hotend fan by default. This can result in users easily running the hotend heater with no fan.

Adjust M106 line so that the hotend fan comes on by default. Add optional commented out M106 line so that users can easily switch the fan to thermostatic mode if desired.
